### PR TITLE
Add GitHub Action to test Qt setup scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
         shell: pwsh
         run: |
           & .\${{ matrix.dir }}\setup.ps1 -QtVersion ${{ matrix.qt_version }} -Compiler msvc2019_64 -InstallPath C:\Qt
-          $val = Get-Item Env:${{ matrix.env_var }} -ErrorAction SilentlyContinue
+          $val = [Environment]::GetEnvironmentVariable("${{ matrix.env_var }}", "User")
           if (-not $val) { throw "${{ matrix.env_var }} not set" }
-          "${{ matrix.env_var }}=$($val.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "${{ matrix.env_var }}=$val" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Verify environment variable
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- add Windows CI workflow to run Qt5 and Qt6 setup scripts
- verify each script sets the expected environment variables

## Testing
- `pwsh -NoProfile -Command "Write-Host 'hi'"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d77b16708322b2dc5588de57989a