### PR TITLE
Fix Qt installer URL in setup scripts

### DIFF
--- a/qt5/setup.ps1
+++ b/qt5/setup.ps1
@@ -10,7 +10,7 @@ if (-not (Test-Path $qtBase)) {
     Write-Host "Qt $QtVersion ($Compiler) が $qtBase に見つかりません。" -ForegroundColor Yellow
     Write-Host "Qtのオンラインインストーラをダウンロードして起動します。セットアップ完了後に再度このスクリプトを実行してください。"
     $installer = Join-Path $env:TEMP "qt-online-installer.exe"
-    Invoke-WebRequest -Uri "https://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe" -OutFile $installer
+    Invoke-WebRequest -Uri "https://download.qt.io/official_releases/online_installers/qt-unified-windows-x64-online.exe" -OutFile $installer
     Start-Process -FilePath $installer -Wait
 }
 

--- a/qt6/setup.ps1
+++ b/qt6/setup.ps1
@@ -10,7 +10,7 @@ if (-not (Test-Path $qtBase)) {
     Write-Host "Qt $QtVersion ($Compiler) が $qtBase に見つかりません。" -ForegroundColor Yellow
     Write-Host "Qtのオンラインインストーラをダウンロードして起動します。セットアップ完了後に再度このスクリプトを実行してください。"
     $installer = Join-Path $env:TEMP "qt-online-installer.exe"
-    Invoke-WebRequest -Uri "https://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe" -OutFile $installer
+    Invoke-WebRequest -Uri "https://download.qt.io/official_releases/online_installers/qt-unified-windows-x64-online.exe" -OutFile $installer
     Start-Process -FilePath $installer -Wait
 }
 


### PR DESCRIPTION
## Summary
- fix download link in qt5 setup script to point to x64 Qt online installer
- fix download link in qt6 setup script to point to x64 Qt online installer

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fc8aad148322b52646d5761fddd9